### PR TITLE
feat: Add SSE subscription support with @Subscription() and @Signal() decorators

### DIFF
--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -10,6 +10,7 @@
     "---Usage Guide---",
     "structure",
     "routers",
+    "subscriptions",
     "middlewares",
     "context",
     "dependency-injection",

--- a/apps/docs/content/docs/routers.mdx
+++ b/apps/docs/content/docs/routers.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Routers"
+title: 'Routers'
 ---
 
-import Table from "@/components/Table";
+import Table from '@/components/Table';
 import Link from 'next/link';
 
 # Routers
@@ -11,15 +11,23 @@ Routes are responsible for handling incoming requests and returning responses to
 Routers works exactly like the native NestJS controllers, but with some tRPC syntax.
 
 <Callout>
-  If you are not sure about the basic concepts of NestJS controllers and tRPC procedures, you can dive into those concepts in their official documentation.
+  If you are not sure about the basic concepts of NestJS controllers and tRPC
+  procedures, you can dive into those concepts in their official documentation.
 </Callout>
 
 <Cards>
-  <Card title="What are NestJS Controllers" href="https://docs.nestjs.com/controllers" />
-  <Card title="What are tRPC Procedures" href="https://trpc.io/docs/server/procedures" />
+  <Card
+    title="What are NestJS Controllers"
+    href="https://docs.nestjs.com/controllers"
+  />
+  <Card
+    title="What are tRPC Procedures"
+    href="https://trpc.io/docs/server/procedures"
+  />
 </Cards>
 
 #### Writing Routers
+
 Let's compare the most basic functionality of tRPC and see how we implement it in NestJS with our adapter, in the following
 example we'll create a simple router with a single route that will get us a list of dogs from our imaginary database.
 
@@ -47,6 +55,7 @@ example we'll create a simple router with a single route that will get us a list
       }
     }
     ```
+
   </Tab>
   <Tab value="tRPC Router">
     ```typescript title="server.ts"
@@ -71,6 +80,7 @@ example we'll create a simple router with a single route that will get us a list
       }
     });
     ```
+
   </Tab>
 </Tabs>
 
@@ -82,14 +92,17 @@ The `@Query(){:tsx}` decorator before the `findAll(){:tsx}` method tells **NestJ
 </Callout>
 
 #### Router registration
-Similar to NestJS providers, we need to register the routers with Nest so that it can perform the injection and type generation. 
+
+Similar to NestJS providers, we need to register the routers with Nest so that it can perform the injection and type generation.
 We do this by editing our module file and adding the routers to the `providers` array of the `@Module(){:tsx}` decorator.
 
 #### Method Decorators
 
 ##### Procedures
+
 While we discussed how to perform data fetching with our adapter, any complete data platform needs a way to modify server-side data as well.
 This can be done by using the right decorator, here is a list of the available procedure decorators:
+
 <br/>
 <Table columns={["Decorator", "Output"]}>
   <Table.Row>
@@ -107,22 +120,30 @@ This can be done by using the right decorator, here is a list of the available p
 </Table>
 
 tRPC procedures may define validation logic for their input and/or output, and validators are also used to infer the types of inputs and outputs in the client-side.
-We can pass those schemas directly to the decorator as shown above.<br/>For me information on how tRPC procedure validation works, check their <Link href={"https://trpc.io/docs/server/validators"} className="underline" target="_blank">official documentation page</Link>.
+We can pass those schemas directly to the decorator as shown above.<br/>For more information on how tRPC procedure validation works, check their <Link href={"https://trpc.io/docs/server/validators"} className="underline" target="\_blank">official documentation page</Link>.
 
 ##### Middlewares
+
 By default every route will be assigned the `publicProcedure` base, but it is possible to use custom middlewares instead our router via the `@UseMiddlewares()` decorator.
-<Table columns={["Decorator", "Output"]}>
+
+<Table columns={['Decorator', 'Output']}>
   <Table.Row>
     <Table.Cell>`@UseMiddlewares(middleware: TRPCMiddleware)`</Table.Cell>
     <Table.Cell>`middleware.query()`</Table.Cell>
   </Table.Row>
 </Table>
-You can read more about the implementation in our <Link href={"/docs/middlewares"} className="underline">Middlewares Guide</Link>.
+You can read more about the implementation in our
+<Link href={'/docs/middlewares'} className="underline">
+  Middlewares Guide
+</Link>
+.
 
 #### Parameter Decorators
+
 In order to grab the request parameters when defining a route method we can use dedicated decorators, such as @Ctx() or @Input(),
 which are available out of the box. Below is a list of the provided decorators and the plain platform-specific objects they represent.
-<br/>
+
+<br />
 <Table>
   <Table.Row>
     <Table.Cell>`@Options()`</Table.Cell>
@@ -148,10 +169,16 @@ which are available out of the box. Below is a list of the provided decorators a
     <Table.Cell>`@Input(key?: string)`</Table.Cell>
     <Table.Cell>`opts.input / opts.input[key]`</Table.Cell>
   </Table.Row>
+  <Table.Row>
+    <Table.Cell>`@Signal()`</Table.Cell>
+    <Table.Cell>`opts.signal` (for subscriptions)</Table.Cell>
+  </Table.Row>
 </Table>
 
 #### Putting it all together
+
 Below is an example of a UserRouter completed with most of the features and decorators mentioned above.
+
 ```typescript filename="user.router.ts" copy
 import { Inject } from '@nestjs/common';
 import { Router, Query, UseMiddlewares, Input } from 'nestjs-trpc-v2';
@@ -193,4 +220,5 @@ export class UserRouter {
 ```
 
 #### Dependency injection
+
 Routers fully supports Dependency Injection. Just as with NestJS providers and controllers, they are able to inject dependencies that are available within the same module. As usual, this is done through the `constructor`.

--- a/apps/docs/content/docs/subscriptions.mdx
+++ b/apps/docs/content/docs/subscriptions.mdx
@@ -1,0 +1,250 @@
+---
+title: 'Subscriptions'
+---
+
+import Table from '@/components/Table';
+import Link from 'next/link';
+
+# Subscriptions
+
+Subscriptions enable real-time event streaming between the server and client using Server-Sent Events (SSE).
+Use subscriptions when you need to push real-time updates to clients.
+
+<Callout>
+  tRPC v11 supports SSE-based subscriptions out of the box. SSE is simpler to
+  set up than WebSockets and works through standard HTTP.
+</Callout>
+
+<Cards>
+  <Card
+    title="tRPC Subscriptions"
+    href="https://trpc.io/docs/server/subscriptions"
+  />
+  <Card
+    title="HTTP Subscription Link"
+    href="https://trpc.io/docs/client/links/httpSubscriptionLink"
+  />
+</Cards>
+
+## Creating a Subscription
+
+Subscriptions use async generator functions that yield values over time. Use the `@Subscription()` decorator to mark a method as a subscription procedure.
+
+```typescript title="notification.router.ts"
+import { Injectable } from '@nestjs/common';
+import { Router, Subscription, Signal } from 'nestjs-trpc-v2';
+import { z } from 'zod';
+
+const notificationSchema = z.object({
+  id: z.string(),
+  message: z.string(),
+  timestamp: z.number(),
+});
+
+@Injectable()
+@Router()
+export class NotificationRouter {
+  @Subscription({ output: notificationSchema })
+  async *onNotification(@Signal() signal?: AbortSignal) {
+    let id = 0;
+    while (!signal?.aborted) {
+      yield {
+        id: String(id),
+        message: `Notification ${id}`,
+        timestamp: Date.now(),
+      };
+      id++;
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+  }
+}
+```
+
+## The @Signal Decorator
+
+The `@Signal()` parameter decorator extracts the `AbortSignal` from the procedure options. This signal is aborted when the client disconnects, allowing you to clean up resources.
+
+```typescript
+@Subscription({ output: messageSchema })
+async *onMessage(@Signal() signal?: AbortSignal) {
+  while (!signal?.aborted) {
+    // Stream messages until client disconnects
+  }
+}
+```
+
+## Using Input with Subscriptions
+
+Subscriptions can accept input parameters just like queries and mutations:
+
+```typescript title="post.router.ts"
+import { Injectable } from '@nestjs/common';
+import { Router, Subscription, Input, Signal } from 'nestjs-trpc-v2';
+import { tracked } from '@trpc/server';
+import { z } from 'zod';
+
+const postSchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  createdAt: z.date(),
+});
+
+@Injectable()
+@Router()
+export class PostRouter {
+  @Subscription({
+    input: z.object({ lastEventId: z.coerce.number().optional() }),
+    output: postSchema,
+  })
+  async *onPostCreated(
+    @Input() input: { lastEventId?: number },
+    @Signal() signal?: AbortSignal,
+  ) {
+    let lastId = input.lastEventId ?? 0;
+
+    while (!signal?.aborted) {
+      const newPosts = await this.postService.findAfter(lastId);
+
+      for (const post of newPosts) {
+        yield tracked(String(post.id), post);
+        lastId = post.id;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+  }
+}
+```
+
+## Tracked Events for Auto-Reconnection
+
+Use the `tracked()` helper from `@trpc/server` to enable automatic reconnection. When a client reconnects, it will receive the `lastEventId` in the input, allowing you to resume from where it left off.
+
+```typescript
+import { tracked } from '@trpc/server';
+
+@Subscription({
+  input: z.object({ lastEventId: z.string().nullish() }),
+  output: messageSchema,
+})
+async *onMessage(
+  @Input() input: { lastEventId?: string | null },
+  @Signal() signal?: AbortSignal,
+) {
+  // Catch up on missed messages
+  if (input.lastEventId) {
+    const missed = await this.messageService.getAfter(input.lastEventId);
+    for (const msg of missed) {
+      yield tracked(msg.id, msg);
+    }
+  }
+
+  // Stream new messages with tracking
+  for await (const msg of this.messageService.subscribe(signal)) {
+    yield tracked(msg.id, msg);
+  }
+}
+```
+
+## Client Setup
+
+On the client side, use `httpSubscriptionLink` with `splitLink` to handle subscriptions:
+
+```typescript title="client.ts"
+import {
+  createTRPCClient,
+  httpBatchLink,
+  httpSubscriptionLink,
+  splitLink,
+} from '@trpc/client';
+import type { AppRouter } from './server/app-router';
+
+const trpc = createTRPCClient<AppRouter>({
+  links: [
+    splitLink({
+      condition: (op) => op.type === 'subscription',
+      true: httpSubscriptionLink({
+        url: 'http://localhost:3000/trpc',
+      }),
+      false: httpBatchLink({
+        url: 'http://localhost:3000/trpc',
+      }),
+    }),
+  ],
+});
+
+// Subscribe to notifications
+const subscription = trpc.notificationRouter.onNotification.subscribe(
+  undefined,
+  {
+    onData: (notification) => {
+      console.log('New notification:', notification);
+    },
+    onError: (err) => {
+      console.error('Subscription error:', err);
+    },
+  },
+);
+
+// Unsubscribe when done
+subscription.unsubscribe();
+```
+
+## Event Emitter Pattern
+
+For real-time events from your application, use Node.js EventEmitter:
+
+```typescript title="chat.router.ts"
+import { Injectable } from '@nestjs/common';
+import { Router, Subscription, Signal } from 'nestjs-trpc-v2';
+import { EventEmitter, on } from 'events';
+import { z } from 'zod';
+
+const messageSchema = z.object({
+  id: z.string(),
+  text: z.string(),
+  userId: z.string(),
+});
+
+@Injectable()
+@Router()
+export class ChatRouter {
+  private readonly events = new EventEmitter();
+
+  @Subscription({ output: messageSchema })
+  async *onMessage(@Signal() signal?: AbortSignal) {
+    for await (const [message] of on(this.events, 'message', { signal })) {
+      yield message;
+    }
+  }
+
+  emitMessage(message: z.infer<typeof messageSchema>) {
+    this.events.emit('message', message);
+  }
+}
+```
+
+## Parameter Decorators
+
+<Table columns={['Decorator', 'Description']}>
+  <Table.Row>
+    <Table.Cell>`@Signal()`</Table.Cell>
+    <Table.Cell>
+      Extracts the `AbortSignal` for detecting client disconnection
+    </Table.Cell>
+  </Table.Row>
+  <Table.Row>
+    <Table.Cell>`@Input()`</Table.Cell>
+    <Table.Cell>
+      Extracts the validated input (including `lastEventId` for reconnection)
+    </Table.Cell>
+  </Table.Row>
+  <Table.Row>
+    <Table.Cell>`@Options()`</Table.Cell>
+    <Table.Cell>Extracts the full procedure options object</Table.Cell>
+  </Table.Row>
+  <Table.Row>
+    <Table.Cell>`@Context()`</Table.Cell>
+    <Table.Cell>Extracts the tRPC context</Table.Cell>
+  </Table.Row>
+</Table>

--- a/packages/nestjs-trpc-v2/lib/decorators/__tests__/signal.decorator.spec.ts
+++ b/packages/nestjs-trpc-v2/lib/decorators/__tests__/signal.decorator.spec.ts
@@ -1,0 +1,69 @@
+import 'reflect-metadata';
+import { Signal } from '../signal.decorator';
+import { PROCEDURE_PARAM_METADATA_KEY } from '../../trpc.constants';
+import { ProcedureParamDecoratorType } from '../../interfaces/factory.interface';
+
+describe('Signal Decorator', () => {
+  it('should set parameter metadata with Signal type', () => {
+    class TestClass {
+      testMethod(@Signal() signal: AbortSignal) {
+        return signal;
+      }
+    }
+
+    const metadata = Reflect.getMetadata(
+      PROCEDURE_PARAM_METADATA_KEY,
+      TestClass.prototype,
+      'testMethod',
+    );
+
+    expect(metadata).toEqual([
+      { type: ProcedureParamDecoratorType.Signal, index: 0 },
+    ]);
+  });
+
+  it('should work with multiple parameter decorators', () => {
+    class TestClass {
+      testMethod(
+        @Signal() signal: AbortSignal,
+        @Signal() anotherSignal: AbortSignal,
+      ) {
+        return { signal, anotherSignal };
+      }
+    }
+
+    const metadata = Reflect.getMetadata(
+      PROCEDURE_PARAM_METADATA_KEY,
+      TestClass.prototype,
+      'testMethod',
+    );
+
+    expect(metadata).toHaveLength(2);
+    expect(metadata).toContainEqual({
+      type: ProcedureParamDecoratorType.Signal,
+      index: 0,
+    });
+    expect(metadata).toContainEqual({
+      type: ProcedureParamDecoratorType.Signal,
+      index: 1,
+    });
+  });
+
+  it('should preserve parameter index when used with other decorators', () => {
+    class TestClass {
+      testMethod(input: unknown, @Signal() signal: AbortSignal) {
+        return signal;
+      }
+    }
+
+    const metadata = Reflect.getMetadata(
+      PROCEDURE_PARAM_METADATA_KEY,
+      TestClass.prototype,
+      'testMethod',
+    );
+
+    expect(metadata).toEqual([
+      { type: ProcedureParamDecoratorType.Signal, index: 1 },
+    ]);
+  });
+});

--- a/packages/nestjs-trpc-v2/lib/decorators/__tests__/subscription.decorator.spec.ts
+++ b/packages/nestjs-trpc-v2/lib/decorators/__tests__/subscription.decorator.spec.ts
@@ -1,0 +1,82 @@
+import 'reflect-metadata';
+import { Subscription } from '../subscription.decorator';
+import {
+  PROCEDURE_METADATA_KEY,
+  PROCEDURE_TYPE_KEY,
+} from '../../trpc.constants';
+import { ProcedureType } from '../../trpc.enum';
+import { z } from 'zod';
+
+describe('Subscription Decorator', () => {
+  it('should set procedure type metadata to Subscription', () => {
+    class TestClass {
+      @Subscription()
+      testMethod() {}
+    }
+
+    const metadata = Reflect.getMetadata(
+      PROCEDURE_TYPE_KEY,
+      TestClass.prototype.testMethod,
+    );
+    expect(metadata).toBe(ProcedureType.Subscription);
+  });
+
+  it('should set procedure metadata with input and output schemas', () => {
+    const inputSchema = z.object({ lastEventId: z.string().optional() });
+    const outputSchema = z.object({ message: z.string() });
+
+    class TestClass {
+      @Subscription({ input: inputSchema, output: outputSchema })
+      testMethod() {}
+    }
+
+    const metadata = Reflect.getMetadata(
+      PROCEDURE_METADATA_KEY,
+      TestClass.prototype.testMethod,
+    );
+    expect(metadata).toEqual({ input: inputSchema, output: outputSchema });
+  });
+
+  it('should set procedure metadata without schemas', () => {
+    class TestClass {
+      @Subscription()
+      testMethod() {}
+    }
+
+    const metadata = Reflect.getMetadata(
+      PROCEDURE_METADATA_KEY,
+      TestClass.prototype.testMethod,
+    );
+    expect(metadata).toBeUndefined();
+  });
+
+  it('should set procedure metadata with only input schema', () => {
+    const inputSchema = z.object({ cursor: z.number().optional() });
+
+    class TestClass {
+      @Subscription({ input: inputSchema })
+      testMethod() {}
+    }
+
+    const metadata = Reflect.getMetadata(
+      PROCEDURE_METADATA_KEY,
+      TestClass.prototype.testMethod,
+    );
+    expect(metadata).toEqual({ input: inputSchema });
+  });
+
+  it('should set procedure metadata with only output schema', () => {
+    const outputSchema = z.object({ data: z.string() });
+
+    class TestClass {
+      @Subscription({ output: outputSchema })
+      testMethod() {}
+    }
+
+    const metadata = Reflect.getMetadata(
+      PROCEDURE_METADATA_KEY,
+      TestClass.prototype.testMethod,
+    );
+    expect(metadata).toEqual({ output: outputSchema });
+  });
+});

--- a/packages/nestjs-trpc-v2/lib/decorators/index.ts
+++ b/packages/nestjs-trpc-v2/lib/decorators/index.ts
@@ -4,6 +4,7 @@ export * from './router.decorator';
 export * from './middlewares.decorator';
 export * from './mutation.decorator';
 export * from './query.decorator';
+export * from './subscription.decorator';
 
 // Procedure Param Decorators
 export * from './options.decorator';
@@ -12,3 +13,4 @@ export * from './input.decorator';
 export * from './raw-input.decorator';
 export * from './type.decorator';
 export * from './path.decorator';
+export * from './signal.decorator';

--- a/packages/nestjs-trpc-v2/lib/decorators/signal.decorator.ts
+++ b/packages/nestjs-trpc-v2/lib/decorators/signal.decorator.ts
@@ -1,0 +1,54 @@
+import {
+  ProcedureParamDecorator,
+  ProcedureParamDecoratorType,
+} from '../interfaces/factory.interface';
+import { PROCEDURE_PARAM_METADATA_KEY } from '../trpc.constants';
+
+/**
+ * Signal procedure parameter decorator. Extracts the `AbortSignal` from the procedure options.
+ * Use this in subscription procedures to detect when the client disconnects.
+ *
+ * @example
+ * ```typescript
+ * @Subscription({ output: z.object({ count: z.number() }) })
+ * async *counter(@Signal() signal?: AbortSignal) {
+ *   let count = 0;
+ *   while (!signal?.aborted) {
+ *     yield { count: count++ };
+ *     await new Promise(resolve => setTimeout(resolve, 1000));
+ *   }
+ * }
+ * ```
+ *
+ * @see [Subscriptions](https://nestjs-trpc-v2.io/docs/subscriptions)
+ *
+ * @publicApi
+ */
+export function Signal(): ParameterDecorator {
+  return (
+    target: object,
+    propertyKey: string | symbol | undefined,
+    parameterIndex: number,
+  ) => {
+    if (propertyKey != null) {
+      const existingParams: Array<ProcedureParamDecorator> =
+        Reflect.getMetadata(
+          PROCEDURE_PARAM_METADATA_KEY,
+          target,
+          propertyKey,
+        ) || [];
+
+      const procedureParamMetadata: ProcedureParamDecorator = {
+        type: ProcedureParamDecoratorType.Signal,
+        index: parameterIndex,
+      };
+      existingParams.push(procedureParamMetadata);
+      Reflect.defineMetadata(
+        PROCEDURE_PARAM_METADATA_KEY,
+        existingParams,
+        target,
+        propertyKey,
+      );
+    }
+  };
+}

--- a/packages/nestjs-trpc-v2/lib/decorators/subscription.decorator.ts
+++ b/packages/nestjs-trpc-v2/lib/decorators/subscription.decorator.ts
@@ -1,0 +1,39 @@
+import { ZodSchema } from 'zod';
+import { applyDecorators, SetMetadata } from '@nestjs/common';
+import { PROCEDURE_METADATA_KEY, PROCEDURE_TYPE_KEY } from '../trpc.constants';
+import { ProcedureType } from '../trpc.enum';
+
+/**
+ * Decorator that marks a router class method as a tRPC subscription procedure.
+ * Subscriptions use async generators to stream real-time events to clients via SSE.
+ *
+ * A tRPC subscription procedure is responsible for streaming real-time data to clients.
+ * The method should be an async generator function that yields values over time.
+ *
+ * @param {object} args configuration object specifying:
+ * - `input` - defines a `ZodSchema` validation logic for the input.
+ * - `output` - defines a `ZodSchema` validation logic for yielded values.
+ *
+ * @example
+ * ```typescript
+ * @Subscription({ output: z.object({ message: z.string() }) })
+ * async *onMessage(@Signal() signal?: AbortSignal) {
+ *   while (!signal?.aborted) {
+ *     yield { message: 'Hello' };
+ *     await new Promise(resolve => setTimeout(resolve, 1000));
+ *   }
+ * }
+ * ```
+ *
+ * @see [Subscriptions](https://nestjs-trpc-v2.io/docs/subscriptions)
+ *
+ * @publicApi
+ */
+export function Subscription(args?: { input?: ZodSchema; output?: ZodSchema }) {
+  return applyDecorators(
+    ...[
+      SetMetadata(PROCEDURE_TYPE_KEY, ProcedureType.Subscription),
+      SetMetadata(PROCEDURE_METADATA_KEY, args),
+    ],
+  );
+}

--- a/packages/nestjs-trpc-v2/lib/generators/__tests__/procedure.generator.spec.ts
+++ b/packages/nestjs-trpc-v2/lib/generators/__tests__/procedure.generator.spec.ts
@@ -66,5 +66,40 @@ describe('ProcedureGenerator', () => {
         );
       });
     });
+
+    describe('for a subscription', () => {
+      it('should generate router string from metadata', () => {
+        const mockProcedure: ProcedureGeneratorMetadata = {
+          name: 'testSubscription',
+          decorators: [{ name: 'Subscription', arguments: {} }],
+        };
+
+        const result =
+          procedureGenerator.generateProcedureString(mockProcedure);
+
+        expect(result).toBe(
+          'testSubscription: publicProcedure.subscription(async () => "PLACEHOLDER_DO_NOT_REMOVE" as any )',
+        );
+      });
+
+      it('should generate subscription with input schema', () => {
+        const mockProcedure: ProcedureGeneratorMetadata = {
+          name: 'onNotification',
+          decorators: [
+            {
+              name: 'Subscription',
+              arguments: { input: 'z.object({ lastEventId: z.string() })' },
+            },
+          ],
+        };
+
+        const result =
+          procedureGenerator.generateProcedureString(mockProcedure);
+
+        expect(result).toBe(
+          'onNotification: publicProcedure.input(z.object({ lastEventId: z.string() })).subscription(async () => "PLACEHOLDER_DO_NOT_REMOVE" as any )',
+        );
+      });
+    });
   });
 });

--- a/packages/nestjs-trpc-v2/lib/generators/decorator.generator.ts
+++ b/packages/nestjs-trpc-v2/lib/generators/decorator.generator.ts
@@ -26,7 +26,11 @@ export class DecoratorGenerator {
       (array, decorator) => {
         const decoratorName = decorator.getName();
 
-        if (decoratorName === 'Query' || decoratorName === 'Mutation') {
+        if (
+          decoratorName === 'Query' ||
+          decoratorName === 'Mutation' ||
+          decoratorName === 'Subscription'
+        ) {
           const input = this.getDecoratorPropertyValue(
             decorator,
             'input',

--- a/packages/nestjs-trpc-v2/lib/generators/procedure.generator.ts
+++ b/packages/nestjs-trpc-v2/lib/generators/procedure.generator.ts
@@ -24,7 +24,8 @@ export class ProcedureGenerator {
     const decorator = decorators.find(
       (decorator) =>
         decorator.name === ProcedureType.Mutation ||
-        decorator.name === ProcedureType.Query,
+        decorator.name === ProcedureType.Query ||
+        decorator.name === ProcedureType.Subscription,
     );
 
     if (!decorator) {

--- a/packages/nestjs-trpc-v2/lib/interfaces/factory.interface.ts
+++ b/packages/nestjs-trpc-v2/lib/interfaces/factory.interface.ts
@@ -10,6 +10,7 @@ export enum ProcedureParamDecoratorType {
   RawInput = 'rawInput',
   Type = 'type',
   Path = 'path',
+  Signal = 'signal',
 }
 
 export type ProcedureImplementation = ({

--- a/packages/nestjs-trpc-v2/lib/interfaces/generator.interface.ts
+++ b/packages/nestjs-trpc-v2/lib/interfaces/generator.interface.ts
@@ -20,7 +20,7 @@ export interface ProcedureGeneratorMetadata {
 }
 
 export interface DecoratorGeneratorMetadata {
-  name: 'Query' | 'Mutation';
+  name: 'Query' | 'Mutation' | 'Subscription';
   arguments: {
     input?: string;
     output?: string;

--- a/packages/nestjs-trpc-v2/lib/interfaces/module-options.interface.ts
+++ b/packages/nestjs-trpc-v2/lib/interfaces/module-options.interface.ts
@@ -8,6 +8,17 @@ export type SchemaImports =
   | object
   | ZodTypeAny;
 
+export interface SSEOptions {
+  ping?: {
+    enabled: boolean;
+    intervalMs?: number;
+  };
+  maxDurationMs?: number;
+  client?: {
+    reconnectAfterInactivityMs?: number;
+  };
+}
+
 /**
  * "TRPCModule" options object.
  */
@@ -50,4 +61,10 @@ export interface TRPCModuleOptions {
    * @link https://trpc.io/docs/data-transformers
    */
   transformer?: DataTransformer;
+
+  /**
+   * Server-sent events (SSE) configuration for subscriptions
+   * @link https://trpc.io/docs/client/links/httpSubscriptionLink
+   */
+  sse?: SSEOptions;
 }

--- a/packages/nestjs-trpc-v2/lib/interfaces/procedure-options.interface.ts
+++ b/packages/nestjs-trpc-v2/lib/interfaces/procedure-options.interface.ts
@@ -5,4 +5,5 @@ export type ProcedureOptions = {
   type: string;
   path: string;
   rawInput: string;
+  signal?: AbortSignal;
 };

--- a/packages/nestjs-trpc-v2/lib/trpc.enum.ts
+++ b/packages/nestjs-trpc-v2/lib/trpc.enum.ts
@@ -1,4 +1,5 @@
 export enum ProcedureType {
   Query = 'Query',
   Mutation = 'Mutation',
+  Subscription = 'Subscription',
 }

--- a/packages/nestjs-trpc-v2/test/e2e/app.module.ts
+++ b/packages/nestjs-trpc-v2/test/e2e/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TRPCModule } from '../../lib';
 import { UserRouter } from './routers/user.router';
 import { PostRouter } from './routers/post.router';
+import { NotificationRouter } from './routers/notification.router';
 
 @Module({
   imports: [
@@ -9,6 +10,6 @@ import { PostRouter } from './routers/post.router';
       autoSchemaFile: './test/e2e/generated',
     }),
   ],
-  providers: [UserRouter, PostRouter],
+  providers: [UserRouter, PostRouter, NotificationRouter],
 })
 export class AppModule {}

--- a/packages/nestjs-trpc-v2/test/e2e/routers/notification.router.ts
+++ b/packages/nestjs-trpc-v2/test/e2e/routers/notification.router.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { Router, Subscription, Input, Signal } from '../../../lib';
+import { z } from 'zod';
+
+@Injectable()
+@Router()
+export class NotificationRouter {
+  @Subscription()
+  async *onNotification(@Signal() signal?: AbortSignal) {
+    let id = 0;
+    while (!signal?.aborted) {
+      yield {
+        id: String(id),
+        message: `Notification ${id}`,
+        timestamp: Date.now(),
+      };
+      id++;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      if (id > 10) break;
+    }
+  }
+
+  @Subscription({
+    input: z.object({ lastEventId: z.string().optional() }),
+  })
+  async *onNotificationWithInput(
+    @Input() input: { lastEventId?: string },
+    @Signal() signal?: AbortSignal,
+  ) {
+    let id = input.lastEventId ? parseInt(input.lastEventId, 10) : 0;
+    while (!signal?.aborted) {
+      yield {
+        id: String(id),
+        message: `Notification ${id}`,
+        timestamp: Date.now(),
+      };
+      id++;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      if (id > 20) break;
+    }
+  }
+}


### PR DESCRIPTION
# Summary
Adds Server-Sent Events (SSE) subscription support to nestjs-trpc-v2, enabling real-time streaming from server to client.

## Changes
- Added `@Subscription()` decorator
```ts
@Subscription({ input: z.object({ lastEventId: z.string().optional() }) })
async *onNotification(
  @Input() input: { lastEventId?: string },
  @Signal() signal: AbortSignal
) {
  while (!signal.aborted) {
    yield { message: 'Hello', timestamp: Date.now() };
    await new Promise((resolve) => setTimeout(resolve, 1000));
  }
}
```
- Added `@Signal()` parameter decorator to access the AbortSignal for detecting client disconnection.
- Added Subscription to ProcedureType enum
- Added Signal to ProcedureParamDecoratorType enum
- ProcedureFactory updated to handle subscription procedures
- Type generators modified to support subscriptions for generated AppRouter
- Added SSEOptions interface for future SSE options
- Added docs page
- 12 new tests for decorators, procedure factory, and E2E streaming
## Notes
- Output schema validation skipped at runtime for subscriptions (tRPC async generator limitation), but still used for type generation
- Subscriptions supported with tRPC httpSubscriptionLink on the client-side
